### PR TITLE
 Flask login version bump 0.5.0 > 0.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ click>=8.0.1 # broken
 discid==1.2.0
 Flask>=2.0.3 # broken
 Flask-Cors==3.0.10
-Flask-Login>=0.5.0 # broken
+Flask-Login>=0.6.1 # broken
 Flask-Migrate==3.1.0
 Flask-SQLAlchemy==2.5.1
 Flask-WTF==1.0.1


### PR DESCRIPTION
Bumps flask login to 0.6.1

This might break Ubuntu 18/ python versions


Failing this being merged, 

Werkzeug will need to be pinned to 2.0.0
instead of 
`Werkzeug>=2.0.3 # broken`
As this would allow 2.1 to be installed, breaking flask-login