### PR TITLE
Fix broken GitHub Action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN \
 # install python reqs
 COPY requirements.txt ./requirements.txt
 RUN pip install --upgrade pip wheel setuptools psutil pyudev
-RUN pip install --ignore-installed -r ./requirements.txt
+RUN pip install --ignore-installed --prefer-binaries -r ./requirements.txt
 
 
 ###########################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN install_clean \
         python3 \
         python3-dev \
         python3-pip \
-        rustc \
-        cargo \
+        #rustc \
+        #cargo \
         nano \
         vim \
         # arm extra requirements

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,9 +69,9 @@ RUN install_clean \
         libavcodec-extra
 
 # install python reqs
-COPY requirements.txt /requirements.txt
+COPY requirements.txt ./requirements.txt
 RUN pip3 install --upgrade pip wheel setuptools psutil pyudev
-RUN pip3 install --ignore-installed --prefer-binary -r /requirements.txt
+RUN pip3 install --ignore-installed --prefer-binary -r ./requirements.txt
 # install libdvd-pkg
 RUN \
     install_clean libdvd-pkg && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,6 @@ RUN install_clean \
         python3 \
         python3-dev \
         python3-pip \
-        rustc \
-        cargo \
         nano \
         vim \
         # arm extra requirements
@@ -77,7 +75,7 @@ RUN \
 
 # install python reqs
 COPY requirements.txt ./requirements.txt
-RUN pip3 install --upgrade pip wheel setuptools psutil pyudev setuptools_rust
+RUN pip3 install --upgrade pip wheel setuptools psutil pyudev
 RUN pip3 install --ignore-installed --prefer-binary -r ./requirements.txt
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN install_clean \
 # install libdvd-pkg
 RUN \
     install_clean libdvd-pkg && \
-    dpkg-reconfigure libdvd-pkg \
+    dpkg-reconfigure libdvd-pkg
 
 # install python reqs
 COPY requirements.txt ./requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,15 +68,18 @@ RUN install_clean \
         default-jre-headless \
         libavcodec-extra
 
+# install libdvd-pkg
+RUN \
+    install_clean libdvd-pkg && \
+    dpkg-reconfigure libdvd-pkg \
+
 # install python reqs
 COPY requirements.txt ./requirements.txt
 RUN pip install --upgrade pip wheel setuptools psutil pyudev
 RUN pip install --ignore-installed --prefer-binary -r ./requirements.txt
-# install libdvd-pkg
-RUN \
-    install_clean libdvd-pkg && \
-    dpkg-reconfigure libdvd-pkg
 
+
+###########################################################
 # install makemkv and handbrake
 FROM deps-ripper as install-makemkv-handbrake
 #RUN apt update && install_clean handbrake-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN \
     dpkg-reconfigure libdvd-pkg
 
 # install makemkv and handbrake
+FROM deps-ripper as install-makemkv-handbrake
 #RUN apt update && install_clean handbrake-cli
 #COPY ./scripts/install_handbrake.sh /install_handbrake.sh
 #RUN chmod +x /install_handbrake.sh && sleep 1 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN install_clean \
         python3 \
         python3-dev \
         python3-pip \
+        rustc \
         nano \
         vim \
         # arm extra requirements

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,8 @@ RUN install_clean \
 
 # install python reqs
 COPY requirements.txt ./requirements.txt
-RUN pip3 install --upgrade pip wheel setuptools psutil pyudev
-RUN pip3 install --ignore-installed --prefer-binary -r ./requirements.txt
+RUN pip install --upgrade pip wheel setuptools psutil pyudev
+RUN pip install --ignore-installed --prefer-binary -r ./requirements.txt
 # install libdvd-pkg
 RUN \
     install_clean libdvd-pkg && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN install_clean \
         python3 \
         python3-dev \
         python3-pip \
-        #rustc \
-        #cargo \
+        rustc \
+        cargo \
         nano \
         vim \
         # arm extra requirements
@@ -78,7 +78,7 @@ RUN \
 # install python reqs
 COPY requirements.txt ./requirements.txt
 RUN pip install --upgrade pip wheel setuptools psutil pyudev
-RUN pip install --ignore-installed --prefer-binaries -r ./requirements.txt
+RUN pip install --ignore-installed --prefer-binary -r ./requirements.txt
 
 
 ###########################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,8 @@ RUN \
 
 # install python reqs
 COPY requirements.txt ./requirements.txt
-RUN pip install --upgrade pip wheel setuptools psutil pyudev
-RUN pip install --ignore-installed --prefer-binary -r ./requirements.txt
+RUN pip3 install --upgrade pip wheel setuptools psutil pyudev setuptools_rust
+RUN pip3 install --ignore-installed --prefer-binary -r ./requirements.txt
 
 
 ###########################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN install_clean \
         python3 \
         python3-dev \
         python3-pip \
-        #rustc \
-        #cargo \
+        rustc \
+        cargo \
         nano \
         vim \
         # arm extra requirements
@@ -77,7 +77,7 @@ RUN \
 
 # install python reqs
 COPY requirements.txt ./requirements.txt
-RUN pip3 install --upgrade pip wheel setuptools psutil pyudev #setuptools_rust
+RUN pip3 install --upgrade pip wheel setuptools psutil pyudev setuptools_rust
 RUN pip3 install --ignore-installed --prefer-binary -r ./requirements.txt
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN install_clean \
         python3 \
         python3-dev \
         python3-pip \
-        rustc \
-        cargo \
+        #rustc \
+        #cargo \
         nano \
         vim \
         # arm extra requirements
@@ -77,7 +77,7 @@ RUN \
 
 # install python reqs
 COPY requirements.txt ./requirements.txt
-RUN pip3 install --upgrade pip wheel setuptools psutil pyudev setuptools_rust
+RUN pip3 install --upgrade pip wheel setuptools psutil pyudev #setuptools_rust
 RUN pip3 install --ignore-installed --prefer-binary -r ./requirements.txt
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN install_clean \
         python3-dev \
         python3-pip \
         rustc \
+        cargo \
         nano \
         vim \
         # arm extra requirements

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN \
 # install python reqs
 COPY requirements.txt ./requirements.txt
 RUN pip install --upgrade pip wheel setuptools psutil pyudev
-RUN pip install --ignore-installed --prefer-binary -r ./requirements.txt
+RUN pip install --ignore-installed -r ./requirements.txt
 
 
 ###########################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,8 @@ RUN install_clean \
 
 # install python reqs
 COPY requirements.txt /requirements.txt
-RUN \
-    pip3 install --upgrade pip wheel setuptools psutil pyudev && \
-    pip3 install --ignore-installed --prefer-binary -r /requirements.txt
+RUN pip3 install --upgrade pip wheel setuptools psutil pyudev
+RUN pip3 install --ignore-installed --prefer-binary -r /requirements.txt
 # install libdvd-pkg
 RUN \
     install_clean libdvd-pkg && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alembic==1.4.3
 apprise==0.9.9
-#bcrypt==4.0.0
-bcrypt==3.2.2
+bcrypt==4.0.1
+#bcrypt==3.2.2
 beautifulsoup4==4.11.1
 certifi==2022.9.24
 cffi==1.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 alembic==1.4.3
 apprise==0.9.9
-bcrypt==4.0.0
+#bcrypt==4.0.0
+bcrypt==3.2.2s
 beautifulsoup4==4.11.1
 certifi==2022.9.24
 cffi==1.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 alembic==1.4.3
 apprise==0.9.9
-bcrypt==4.0.1
-#bcrypt==3.2.2
+bcrypt==3.2.2
 beautifulsoup4==4.11.1
 certifi==2022.9.24
 cffi==1.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alembic==1.4.3
 apprise==0.9.9
-bcrypt==4.0.0
-#bcrypt==3.2.2s
+#bcrypt==4.0.0
+bcrypt==3.2.2
 beautifulsoup4==4.11.1
 certifi==2022.9.24
 cffi==1.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alembic==1.4.3
 apprise==0.9.9
-#bcrypt==4.0.0
-bcrypt==3.2.2s
+bcrypt==4.0.0
+#bcrypt==3.2.2s
 beautifulsoup4==4.11.1
 certifi==2022.9.24
 cffi==1.15.1


### PR DESCRIPTION
Turns out the reason the builds kept breaking was because the `bcrypt` dependencies was set to 4.0.0. This version re-implemented bcrypt in rust, and rust toolchain doesn't seem to have a working toolchain for `armv7`, the environment the Action executes the build in.

Rolling back to `bcrypt==3.2.2` has solved the problem. While there may be security implications, any risk reintroduced by this rollback is mitigated by the fact that ARM is not intended to ever touch the greater internet