### PR TITLE
Add dependencies for ripping and labeling MP3s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,6 @@ VOLUME /etc/arm/config
 FROM deps-docker AS deps-ripper
 RUN install_clean \
         abcde \
-        eyed3 \
         atomicparsley \
         cdparanoia \
         eject \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,12 +61,17 @@ RUN install_clean \
         atomicparsley \
         cdparanoia \
         eject \
+        eyeD3 \
         ffmpeg \
         flac \
         glyrc \
         default-jre-headless \
+        id3 \
+        id3v2 \
+        lame \
         libavcodec-extra \
-        lsdvd
+        lsdvd \
+        mp3gain
 
 # install libdvd-pkg
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,10 @@ VOLUME /etc/arm/config
 FROM deps-docker AS deps-ripper
 RUN install_clean \
         abcde \
+        eyed3 \
         atomicparsley \
         cdparanoia \
         eject \
-        eyeD3 \
         ffmpeg \
         flac \
         glyrc \
@@ -69,8 +69,7 @@ RUN install_clean \
         id3v2 \
         lame \
         libavcodec-extra \
-        lsdvd \
-        mp3gain
+        lsdvd
 
 # install libdvd-pkg
 RUN \


### PR DESCRIPTION
Currently the automatic-ripping-machine Docker image cannot rip CDs to MP3 files.

```
[ERROR] abcde: lame is not in your path.
[INFO] Define the full path to the executable if it exists on your system.
[INFO] Hint: sudo apt-get install lame
[03-19-2023 15:53:31] ERROR ARM: Call to abcde failed with code: 1 (b'')
[03-19-2023 15:53:31] INFO ARM: Music rip failed.  See previous errors.  Exiting.
```

This commit installs dependencies for ripping MP3s and writing their ID3 and ID3v2 tags.