### PR TITLE
Revert "Bump werkzeug from 2.3.6 to 3.0.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,6 @@ tinydownload==0.1.0
 urllib3==2.0.4 # broken
 waitress==2.1.2
 wcwidth==0.2.13
-Werkzeug==3.0.3
+Werkzeug==2.3.6
 WTForms==3.0.1
 xmltodict==0.13.0


### PR DESCRIPTION
Reverts automatic-ripping-machine/arm-dependencies#302

2.3.6 required for ARM to use 'url_encode'