### PR TITLE
Packages not imported removed.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,6 @@
 alembic==1.14.1
 apprise==1.7.6
 bcrypt==3.2.2 # Newer versions dont have Wheel
-beautifulsoup4==4.12.3
-certifi==2025.1.31
-cffi==1.16.0
-click==8.1.8
-charset-normalizer==3.4.1
 discid==1.2.0
 Flask==2.2.5 # broken
 Flask-Cors==4.0.0
@@ -22,24 +17,15 @@ Markdown==3.8.2
 MarkupSafe==2.1.3
 musicbrainzngs==0.7.1
 netifaces==0.11.0
-oauthlib==3.2.2
 prettytable==3.10.0
 psutil==6.1.1
-pycparser==2.21
-pycurl==7.45.2
 pydvdid==1.1
 PyYAML==6.0.2
 pyudev==0.24.3
 requests==2.32.3
-requests-oauthlib==1.3.1
-robobrowser==0.5.3
-six==1.16.0
-soupsieve==2.5
 SQLAlchemy==2.0.19
-tinydownload==0.1.0
 urllib3==2.3.0 # broken
 waitress==2.1.2
-wcwidth==0.2.13
 Werkzeug==2.3.6
 WTForms==3.0.1
 xmltodict==0.13.0


### PR DESCRIPTION

# Packages not imported removed.

# Description
pip freeze lists all packages that are installed, including sub packages. This can create conflicts and confusion for future package updates. Packages that are not imported directly in the project should be left to their own projects to manage.

This PR will also allow for an easier merge of 
[https://github.com/automatic-ripping-machine/automatic-ripping-machine/pull/1489](1489) Port track 99 detection to python 

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Docker
- [ ] Other (Please state here)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have tested that my fix is effective or that my feature works